### PR TITLE
Fix login

### DIFF
--- a/plugin.audio.prime_music/default.py
+++ b/plugin.audio.prime_music/default.py
@@ -1209,7 +1209,7 @@ def login(content = None, statusOnly = False):
                 dev_id = cookie.value.replace("-", "")
                 addon.setSetting('req_dev_id', dev_id)
         content = getUnicodePage(urlMainS)
-        customer_match = re.compile('"customerID":"(.+?)"', re.DOTALL).findall(music_content)
+        customer_match = re.compile('"customerId":"(.+?)"', re.DOTALL).findall(music_content)
         if customer_match:
             addon.setSetting('customerID', customer_match[0])
             log(customer_match[0])

--- a/plugin.audio.prime_music/default.py
+++ b/plugin.audio.prime_music/default.py
@@ -1119,10 +1119,10 @@ def login(content = None, statusOnly = False):
     is_prime_expression = "config.isPrimeMember',true"
     if content is None:
         content = getUnicodePage(urlMainS)
-    signoutmatch = re.compile("declare\('config.signOutText',(.+?)\);", re.DOTALL).findall(content)
+    signed_in_expression = "config.signInOverride', false"
     if is_prime_expression in content: #
         return "prime"
-    elif signoutmatch and signoutmatch[0].strip() != "null":
+    elif signed_in_expression in content:
         return "noprime"
     else:
         if statusOnly:
@@ -1213,10 +1213,9 @@ def login(content = None, statusOnly = False):
         if customer_match:
             addon.setSetting('customerID', customer_match[0])
             log(customer_match[0])
-        signoutmatch = re.compile("declare\('config.signOutText',(.+?)\);", re.DOTALL).findall(content)
         if is_prime_expression in content: #
             return "prime"
-        elif signoutmatch[0].strip() != "null":
+        elif signed_in_expression in content:
             return "noprime"
         else:
             return "none"


### PR DESCRIPTION
Hallo Piet, ich habe mir das Login-Problem angeschaut und nach diesen Anpassungen konnte ich mich wieder anmelden:

- `declare('config.signOutText'` fehlte bei mir im Dokument komplett, was zum oft genannten "list index out of range" Fehler beim matching führte. Ich verwende nun `config.signInOverride, false` zur Erkennung eines erfolreichen Logins.

- Die Schreibung von `customerID` hat sich geändert -> `customerId`. Dadurch konnte selbst nach erfolreicher Anmeldung keine Musik geholt werden ("CUSTOMER_INFO_NOT_PROVIDED").
