### PR TITLE
Refactor login

### DIFF
--- a/plugin.audio.prime_music/default.py
+++ b/plugin.audio.prime_music/default.py
@@ -1049,9 +1049,15 @@ def search(type):
         search_string = urllib.quote_plus(search_string.encode("utf8"))
         if siteVersion=="de":
             if type=="albums":
-                listAlbums(urlMain+"/s?rh=n%3A5686557031%2Ck%2Cp_n_format_browse-bin%3A180848031&keywords="+search_string+"&ie=UTF8")
+                if addon.getSetting('access') == 'unlimited':
+                    listAlbums(urlMain+"/s?rh=n%3A77195031%2Ck%2Cp_n_music_subscription%3A10212696031%2Cp_n_format_browse-bin%3A180848031&keywords="+search_string+"&ie=UTF8")
+                else:
+                    listAlbums(urlMain+"/s?rh=n%3A5686557031%2Ck%2Cp_n_format_browse-bin%3A180848031&keywords="+search_string+"&ie=UTF8")
             elif type=="songs":
-                listSearchedSongs(urlMain+"/s/ref=sr_nr_p_n_format_browse-bi_2?fst=as%3Aoff&rh=n%3A5686557031%2Ck%2Cp_n_format_browse-bin%3A180849031&bbn=5686557031&keywords="+search_string+"&ie=UTF8")
+                if addon.getSetting('access') == 'unlimited':
+				    listSearchedSongs(urlMain+"/s/ref=sr_nr_p_n_format_browse-bi_2?fst=as%3Aoff&rh=n%3A77195031%2Ck%2Cp_n_format_browse-bin%3A180849031%2Cp_n_music_subscription%3A10212696031&keywords="+search_string+"&ie=UTF8")
+                else:
+                    listSearchedSongs(urlMain+"/s/ref=sr_nr_p_n_format_browse-bi_2?fst=as%3Aoff&rh=n%3A5686557031%2Ck%2Cp_n_format_browse-bin%3A180849031&bbn=5686557031&keywords="+search_string+"&ie=UTF8")
 #        elif siteVersion=="com":
 #            if type=="movies":
 #                listMovies(urlMain+"/mn/search/ajax/?_encoding=UTF8&url=node%3D7613704011&field-keywords="+search_string)

--- a/plugin.audio.prime_music/default.py
+++ b/plugin.audio.prime_music/default.py
@@ -78,7 +78,7 @@ if addon.getSetting('ssl_verif') == 'true' and hasattr(ssl, '_create_unverified_
 
 def index():
     loginResult = login()
-    if loginResult=="prime":
+    if loginResult=="success":
         addDir(translation(30002), urlMain+"/s/ref=dmm_pr_bbx_album?ie=UTF8&bbn=5686557031&rh=i%3Adigital-music-album", 'listAlbums', "")
         addDir(translation(30003), urlMain+"/s/ref=s9_rbpl_bw_srch?__mk_de_DE=%C5M%C5Z%D5%D1&rh=i%3Adigital-music-playlist%2Cn%3A5686557031%2Cp_n_format_browse-bin%3A5686558031&sort=featured-rank", 'listAlbums', "")
         addDir(translation(30004), "", 'listGenres', "")
@@ -93,6 +93,8 @@ def index():
         xbmcplugin.endOfDirectory(pluginhandle)
     elif loginResult == "captcha_req":
         xbmc.executebuiltin(unicode('XBMC.Notification(Info:,'+translation(30083)+',10000,'+icon+')').encode("utf-8"))
+    elif loginResult == "noprime":
+        xbmc.executebuiltin(unicode('XBMC.Notification(Info:,'+translation(30084)+',10000,'+icon+')').encode("utf-8"))
     else:
         xbmc.executebuiltin(unicode('XBMC.Notification(Info:,'+translation(30082)+',10000,'+icon+')').encode("utf-8"))
 
@@ -392,6 +394,7 @@ def deleteCookies():
     addon.setSetting('csrf_Token', "")
     addon.setSetting('req_dev_id', "")
     addon.setSetting('customerID', "")
+    addon.setSetting('access', "")
 
 
 def deleteCache():
@@ -996,8 +999,7 @@ def trackPostUnicodeGetHLSPage(url, asin, isRetry = False):
             content = unicode(req.read(), "utf-8")
     except urllib2.HTTPError as e:
         log(unicode(e.read(), "utf-8"))
-        deleteCookies()
-        login("dummy")
+        doLogin()
         if not isRetry:
             return trackPostUnicodeGetHLSPage(url, asin, True)
 
@@ -1120,82 +1122,95 @@ def deletePassword():
     writeConfig('foo_bar', '')
 
 
-def login(content = None, statusOnly = False):
-    is_prime_expression = "config.isPrimeMember',true"
-    if content is None:
-        content = getUnicodePage(urlMainS)
-    signed_in_expression = "config.signInOverride', false"
-    if is_prime_expression in content: #
-        return "prime"
-    elif signed_in_expression in content:
-        return "noprime"
+def login():
+    status = checkLoginStatus()
+    if status == "none":
+        return doLogin()
     else:
-        if statusOnly:
-            return "none"
-        deleteCookies()
-        content = ""
+        return status
 
-        email = addon.getSetting('email')
-        pw = decode(getConfig('foo_bar'))
-        if pw:
-            password = unicode(pw, "utf-8")
-        else:
-            password = pw
-        if not email:
-            keyboard = xbmc.Keyboard('', translation(30090))
-            keyboard.doModal()
-            if keyboard.isConfirmed() and unicode(keyboard.getText(), "utf-8"):
-                email = unicode(keyboard.getText(), "utf-8")
-        if not password:
-            password = unicode(requestPassword(), "utf-8")
-        br = mechanize.Browser()
-        br.set_cookiejar(cj)
-        br.set_handle_gzip(True)
-        br.set_handle_robots(False)
-        br.addheaders = [('User-Agent', userAgent)]
-        content = br.open(urlMainS+"/gp/aw/si.html")
-        br.select_form(name="signIn")
-        br["email"] = email
-        br["password"] = password
-        br.addheaders = [('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'),
-                 ('Accept-Encoding', 'gzip, deflate'),
-                 ('Accept-Language', 'de,en-US;q=0.7,en;q=0.3'),
-                 ('Cache-Control', 'no-cache'),
-                 ('Connection', 'keep-alive'),
-                 ('Content-Type', 'application/x-www-form-urlencoded'),
-                 ('User-Agent', userAgent),
-                 ('Upgrade-Insecure-Requests', '1')]
+
+def doLogin():
+    deleteCookies()
+    email = addon.getSetting('email')
+    pw = decode(getConfig('foo_bar'))
+    if pw:
+        password = unicode(pw, "utf-8")
+    else:
+        password = pw
+    if not email:
+        keyboard = xbmc.Keyboard('', translation(30090))
+        keyboard.doModal()
+        if keyboard.isConfirmed() and unicode(keyboard.getText(), "utf-8"):
+            email = unicode(keyboard.getText(), "utf-8")
+    if not password:
+        password = unicode(requestPassword(), "utf-8")
+    br = mechanize.Browser()
+    br.set_cookiejar(cj)
+    br.set_handle_gzip(True)
+    br.set_handle_robots(False)
+    br.addheaders = [('User-Agent', userAgent)]
+    content = br.open(urlMainS+"/gp/aw/si.html")
+    br.select_form(name="signIn")
+    br["email"] = email
+    br["password"] = password
+    br.addheaders = [('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'),
+             ('Accept-Encoding', 'gzip, deflate'),
+             ('Accept-Language', 'de,en-US;q=0.7,en;q=0.3'),
+             ('Cache-Control', 'no-cache'),
+             ('Connection', 'keep-alive'),
+             ('Content-Type', 'application/x-www-form-urlencoded'),
+             ('User-Agent', userAgent),
+             ('Upgrade-Insecure-Requests', '1')]
+    br.submit()
+    resp = br.response().read()
+    content = unicode(resp, "utf-8")
+    while 'auth-mfa-form' in content :
+        soup = parseHTML(content)
+        log('MFA form')
+        if 'auth-mfa-form' in content:
+            msg = soup.find('form', attrs={'id': 'auth-mfa-form'})
+            msgtxt = msg.p.renderContents().strip()
+            kb = xbmc.Keyboard('', msgtxt)
+            kb.doModal()
+            if kb.isConfirmed() and kb.getText():
+                xbmc.executebuiltin('ActivateWindow(busydialog)')
+                br.select_form(nr=0)
+                br['otpCode'] = kb.getText()
+            else:
+                return "none"
         br.submit()
         resp = br.response().read()
         content = unicode(resp, "utf-8")
-        while 'auth-mfa-form' in content :
-            soup = parseHTML(content)
-            log('MFA form')
-            if 'auth-mfa-form' in content:
-                msg = soup.find('form', attrs={'id': 'auth-mfa-form'})
-                msgtxt = msg.p.renderContents().strip()
-                kb = xbmc.Keyboard('', msgtxt)
-                kb.doModal()
-                if kb.isConfirmed() and kb.getText():
-                    xbmc.executebuiltin('ActivateWindow(busydialog)')
-                    br.select_form(nr=0)
-                    br['otpCode'] = kb.getText()
-                else:
-                    return "none"
-            br.submit()
-            resp = br.response().read()
-            content = unicode(resp, "utf-8")
-            soup = parseHTML(content)
-            xbmc.executebuiltin('Dialog.Close(busydialog)')
-        content = content.replace("\\","")
-        captcha_match = re.compile('ap_captcha_title', re.DOTALL).findall(content)
-        if captcha_match:
-            log("Captcha required!")
-            return "captcha_req"
-        br.open("https://music.amazon.de")
-        music_response = br.response().read()
-        music_content = unicode(music_response, "utf-8")
-        music_content = music_content.replace("\\","")
+        soup = parseHTML(content)
+        xbmc.executebuiltin('Dialog.Close(busydialog)')
+    content = content.replace("\\","")
+    captcha_match = re.compile('ap_captcha_title', re.DOTALL).findall(content)
+    if captcha_match:
+        log("Captcha required!")
+        return "captcha_req"
+    return checkLoginStatus(True)
+
+
+def checkLoginStatus(updateSettings = False):
+    signed_out_expression = '"customerId":0'
+    is_unlimited_expression = '"hawkfireAccess":1'
+    is_prime_expression = '"primeAccess":1'
+    access = "none"
+    music_content = getUnicodePage("https://music.amazon.de")
+    music_content = music_content.replace("\\","")
+    if signed_out_expression in music_content:
+        return "none"
+    elif is_unlimited_expression in music_content:
+        access = "unlimited"
+    elif is_prime_expression in music_content:
+        access = "prime"
+    else:
+        return "noprime"
+
+    if updateSettings:
+        addon.setSetting('access', access)
+        log('access: ' + access)
         match = re.compile('"csrf_ts":"(.+?)"', re.DOTALL).findall(music_content)
         if match:
             addon.setSetting('csrf_tsToken', match[0])
@@ -1213,17 +1228,11 @@ def login(content = None, statusOnly = False):
             if cookie.name == "ubid-acbde":
                 dev_id = cookie.value.replace("-", "")
                 addon.setSetting('req_dev_id', dev_id)
-        content = getUnicodePage(urlMainS)
         customer_match = re.compile('"customerId":"(.+?)"', re.DOTALL).findall(music_content)
         if customer_match:
             addon.setSetting('customerID', customer_match[0])
             log(customer_match[0])
-        if is_prime_expression in content: #
-            return "prime"
-        elif signed_in_expression in content:
-            return "noprime"
-        else:
-            return "none"
+    return "success"
 
 
 def parseHTML(response):

--- a/plugin.audio.prime_music/resources/language/English/strings.xml
+++ b/plugin.audio.prime_music/resources/language/English/strings.xml
@@ -36,8 +36,9 @@
   <string id="30039">Soundtracks</string>
   <string id="30040">International</string>
   <string id="30081">Please select the site version (US/UK/DE)...</string>
-  <string id="30082">You are not logged in or used an Amazon account that does not have Prime priviliges</string>
+  <string id="30082">You are not logged in</string>
   <string id="30083">Captcha Request, please change IP or try again later</string>
+  <string id="30084">Your Amazon account does not have Prime or Music Unlimited priviliges</string>
   <string id="30090">Amazon Prime Music - Enter your Email:</string>
   <string id="30091">Amazon Prime Music - Enter your Password:</string>
   <string id="30101">Email</string>

--- a/plugin.audio.prime_music/resources/language/German/strings.xml
+++ b/plugin.audio.prime_music/resources/language/German/strings.xml
@@ -36,8 +36,9 @@
   <string id="30039">Soundtracks</string>
   <string id="30040">Weltmusik</string>
   <string id="30081">Bitte die Seitenversion (US/UK/DE) wählen...</string>
-  <string id="30082">Du bist nicht eingeloggt oder hast keinen Amazon Prime Account zum einloggen verwendet</string>
+  <string id="30082">Du bist nicht eingeloggt</string>
   <string id="30083">Captcha Abfrage, bitte IP ändern oder später erneut versuchen</string>
+  <string id="30084">Du hast keinen Amazon Prime oder Music Unlimited Account zum einloggen verwendet</string>
   <string id="30090">Amazon Prime Music - Email eingeben:</string>
   <string id="30091">Amazon Prime Music - Password eingeben:</string>
   <string id="30101">Email</string>

--- a/plugin.audio.prime_music/resources/settings.xml
+++ b/plugin.audio.prime_music/resources/settings.xml
@@ -10,6 +10,7 @@
         <setting id="email" type="text" visible="false" label="email" default=""/>
         <setting id="password" type="text" visible="false" label="password" default=""/>
         <setting id="req_dev_id" type="text" visible="false" label="req_dev_id" default=""/>
+        <setting id="access" type="text" visible="false" label="access" default=""/>
     </category>
     <category label="30121">
         <setting id="albumDefaultView" type="text" label="30119"/>


### PR DESCRIPTION
Hallo Piet, ich habe den Login-Vorgang wie folgendermaßen umgebaut:
- Der Login- und Prime Status wird nicht mehr von www.amazon.de sondern von music.amazon.de geholt.
- Dadurch kann zusätzlich auch der Music Unlimited Status festgestellt werden. Das ist wichtig für User, die nur Unlimited aber kein Prime haben und sich bisher nicht anmelden konnten. Für mich war das vor einigen Monaten der Grund, überhaupt in den Code zu schauen und ihn lokal zu patchen. :P
- Die Erkennung für das MFA-Formular funktioniert jetzt wieder. Ich kann mir eine Mail zusenden lassen und mich dann per Code-Eingabe verifizieren. Falls vorhanden, müssten andere MFA-Modi noch getestet werden.
- Dank der Unlimited-Erkennung kann jetzt auch jeweils die passende URL für die Suche nach Alben und Songs ausgewählt werden.


