### PR TITLE
Fix expression checking for signed-out state

### DIFF
--- a/plugin.audio.prime_music/default.py
+++ b/plugin.audio.prime_music/default.py
@@ -1240,7 +1240,7 @@ def doLogin():
 
 def checkLoginStatus(updateSettings = False):
     sign_in_form_expression = 'name="signIn"'
-    signed_out_expression = '"customerId":0'
+    signed_out_expression = '"customerId":""'
     is_unlimited_expression = '"hawkfireAccess":true'
     is_prime_expression = '"primeAccess":true'
     access = "none"


### PR DESCRIPTION
Hallo Piet, bei der letzten Anpassung seitens Amazon hat sich auch die Ausgabe der customerID geändert. Ergebnis: Es wurde bei mir nicht mehr festgestellt, dass ich abgemeldet bin und kein Login-Versuch unternommen.